### PR TITLE
Add missing CGAL dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -111,7 +111,7 @@ RUN curl -sL https://deb.nodesource.com/setup_9.x | sudo -E bash - && \
 apt-get install -y nodejs
 
 # Install CGAL for WoR
-RUN apt-get install -y libcgal-dev
+RUN apt-get install -y libcgal-dev libcgal-qt5-dev
 
 # Standard SSH port
 EXPOSE 22


### PR DESCRIPTION
CGAL's CMake Module werkt niet als niet ook de qt5-headers voor CGAL geïnstalleerd zijn, daarom zijn deze toegevoegd aan de installatie.