### PR TITLE
Update Dockerfile for JDK 17.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 # This Dockerfile is used to build an image containing basic stuff to be used as a Jenkins slave build node.
 FROM debian:latest
+RUN apt-get update && apt-get upgrade -y
 MAINTAINER Rody Middelkoop <rody.middelkoop@gmail.com>
 
 # Add locales after locale-gen as needed
@@ -24,11 +25,11 @@ RUN \
   echo "deb http://ppa.launchpad.net/linuxuprising/java/ubuntu bionic main" | tee /etc/apt/sources.list.d/linuxuprising-java.list && \
   apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 73C3DB2A && \
   apt-get -q update && \
-  echo oracle-java15-installer shared/accepted-oracle-license-v1-2 select true | /usr/bin/debconf-set-selections && \
+  echo oracle-java17-installer shared/accepted-oracle-license-v1-3 select true | /usr/bin/debconf-set-selections && \
   apt-get update && \
-  apt-get install -y oracle-java15-installer oracle-java15-set-default && \
+  apt-get install -y oracle-java17-installer oracle-java17-set-default && \
   rm -rf /var/lib/apt/lists/* && \
-  rm -rf /var/cache/oracle-jdk15-installer
+  rm -rf /var/cache/oracle-jdk17-installer
 
 # Define working directory.
 WORKDIR /data

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,13 @@ RUN \
   apt-get install -y oracle-java17-installer oracle-java17-set-default && \
   rm -rf /var/lib/apt/lists/* && \
   rm -rf /var/cache/oracle-jdk17-installer
+  
+RUN \
+  apt-get -q update && \
+  apt-get install curl -y && \
+  cd usr/lib/jvm &&  curl -O https://download.java.net/java/GA/jdk15.0.1/51f4f36ad4ef43e39d0dfdbaf6549e32/9/GPL/openjdk-15.0.1_linux-x64_bin.tar.gz && \
+  tar -xvzf openjdk-15.0.1_linux-x64_bin.tar.gz && \
+  rm -rf openjdk-15.0.1_linux-x64_bin.tar.gz
 
 # Define working directory.
 WORKDIR /data


### PR DESCRIPTION
Line 3: Toegevoegd zodat docker image updated is voor updates voor debian en debian download repository lists, anders geen JDK 17 mogelijk.

Line 27/28 - 31/32: Veranderd JDK15 -> JDK17 om zo de nieuwe JDK17 op dockerimage te krijgen.